### PR TITLE
updated feeding modals

### DIFF
--- a/app/.server/tracking.ts
+++ b/app/.server/tracking.ts
@@ -80,7 +80,7 @@ export interface PhotoUpdateData {
 }
 
 export async function trackElimination(
-  prisma: PrismaClient,
+  prisma: any,
   request: Request,
   data: EliminationData
 ) {
@@ -94,7 +94,7 @@ export async function trackElimination(
 }
 
 export async function trackFeeding(
-  prisma: PrismaClient,
+  prisma: any,
   request: Request,
   data: FeedingData
 ) {
@@ -105,7 +105,7 @@ export async function trackFeeding(
 }
 
 export async function trackSleep(
-  prisma: PrismaClient,
+  prisma: any,
   request: Request,
   data: SleepData
 ) {
@@ -116,7 +116,7 @@ export async function trackSleep(
 }
 
 export async function trackPhoto(
-  prisma: PrismaClient,
+  prisma: any,
   request: Request,
   data: PhotoData
 ) {
@@ -153,7 +153,7 @@ export async function editElimination(
 }
 
 export async function editFeeding(
-  prisma: PrismaClient,
+  prisma: any,
   request: Request,
   id: number,
   data: FeedingUpdateData
@@ -166,7 +166,7 @@ export async function editFeeding(
 }
 
 export async function editSleep(
-  prisma: PrismaClient,
+  prisma: any,
   request: Request,
   id: number,
   data: SleepUpdateData
@@ -179,7 +179,7 @@ export async function editSleep(
 }
 
 export async function editPhoto(
-  prisma: PrismaClient,
+  prisma: any,
   request: Request,
   id: number,
   data: PhotoUpdateData
@@ -192,7 +192,7 @@ export async function editPhoto(
 }
 
 export async function deletePhoto(
-  prisma: PrismaClient,
+  prisma: any,
   request: Request,
   id: number
 ) {
@@ -223,7 +223,7 @@ export async function deletePhoto(
 }
 
 export async function getRecentTrackingEvents(
-  prisma: PrismaClient,
+  prisma: any,
   request: Request,
   babyId: number,
   limit: number = 5
@@ -263,7 +263,7 @@ export async function getRecentTrackingEvents(
 
   // Generate signed URLs for photos
   const signedPhotos = await Promise.all(
-    photos.map(async (photo) => {
+    photos.map(async (photo: any) => {
       try {
         const signedUrl = await createDownloadUrl(photo.url);
         return {
@@ -287,7 +287,7 @@ export async function getRecentTrackingEvents(
 }
 
 export async function getElimination(
-  prisma: PrismaClient,
+  prisma: any,
   request: Request,
   id: number
 ) {
@@ -298,7 +298,7 @@ export async function getElimination(
 }
 
 export async function getFeeding(
-  prisma: PrismaClient,
+  prisma: any,
   request: Request,
   id: number
 ) {
@@ -309,7 +309,7 @@ export async function getFeeding(
 }
 
 export async function getSleep(
-  prisma: PrismaClient,
+  prisma: any,
   request: Request,
   id: number
 ) {
@@ -320,7 +320,7 @@ export async function getSleep(
 }
 
 export async function getPhoto(
-  prisma: PrismaClient,
+  prisma: any,
   request: Request,
   id: number
 ) {

--- a/app/components/tracking/TrackingModal.tsx
+++ b/app/components/tracking/TrackingModal.tsx
@@ -12,6 +12,8 @@ interface Field {
   placeholder?: string;
   accept?: string;
   dragDrop?: boolean;
+  defaultValue?: string | number | null;
+  onChange?: (e: React.ChangeEvent<any>) => void;
 }
 
 interface TrackingModalProps {
@@ -176,6 +178,8 @@ export function TrackingModal({
             name={field.id}
             className={inputClasses}
             required={field.required}
+            defaultValue={field.defaultValue || ""}
+            onChange={field.onChange}
           >
             {field.options?.map((option) => (
               <option key={option.value} value={option.value}>
@@ -203,6 +207,20 @@ export function TrackingModal({
             className="w-full p-2 border rounded bg-black text-white"
             required={field.required}
             placeholder={field.placeholder}
+          />
+        );
+      case "number":
+        return (
+          <input
+            id={`field.${field.id}`}
+            name={field.id}
+            type="number"
+            className="w-full p-2 border rounded bg-black text-white"
+            required={field.required}
+            placeholder={field.placeholder}
+            defaultValue={field.defaultValue || ""}
+            min={0}
+            step="any"
           />
         );
       default:
@@ -237,7 +255,18 @@ export function TrackingModal({
               <label htmlFor={field.id} className={labelClasses}>
                 {field.label}
               </label>
-              {renderField(field)}
+              {field.type === "datetime-local" ? (
+                <input
+                  id={`field.${field.id}`}
+                  type="datetime-local"
+                  name={field.id}
+                  defaultValue={field.defaultValue || ""}
+                  className={inputClasses}
+                  required={field.required}
+                />
+              ) : (
+                renderField(field)
+              )}
             </div>
           ))}
 

--- a/app/src/translations/en.ts
+++ b/app/src/translations/en.ts
@@ -29,6 +29,12 @@ export const en = {
     noBabies: "No babies added yet.",
   },
   tracking: {
+    edit: {
+      elimination: "Edit Elimination",
+      feeding: "Edit Feeding",
+      sleep: "Edit Sleep",
+      photo: "Edit Photo",
+    },
     when: "When",
     type: "Type",
     notes: "Notes",

--- a/app/src/translations/es.ts
+++ b/app/src/translations/es.ts
@@ -32,6 +32,12 @@ export const es: TranslationKeys = {
     noBabies: "Aún no hay bebés agregados.",
   },
   tracking: {
+    edit: {
+      elimination: "Editar Eliminación",
+      feeding: "Editar Alimentación",
+      sleep: "Editar Sueño",
+      photo: "Editar Foto",
+    },
     when: "Cuándo",
     type: "Tipo",
     notes: "Notas",


### PR DESCRIPTION
Updated the 'feeding' modals (`track/feeding, edit/feeding`) 
- Added missing translation keys
- Updated their UI:
<img width="715" alt="image" src="https://github.com/user-attachments/assets/98a7e36e-fa62-435c-8792-e2e58ccc999c" />

<img width="743" alt="image" src="https://github.com/user-attachments/assets/b8311c02-7ab8-4b72-bd90-ae03d6efb3a2" />

- Conditional field rendering for each type:
 Breast: Side
 Bottle: Amount (ml)
 Solid: Food 
 [Formula temporarily removed]
 
 -Fixed a PrismaClient mismatch error by updating prisma to `any` on every trackType function at `tracking.ts`
 
<img width="876" alt="image" src="https://github.com/user-attachments/assets/0e2f7157-f9ef-4b15-a314-ab93eb3e1ae8" />
 
