### PR TITLE
add missing dashboard translations

### DIFF
--- a/app/components/tracking/TrackingModal.tsx
+++ b/app/components/tracking/TrackingModal.tsx
@@ -84,6 +84,22 @@ export function TrackingModal({
     "w-full p-2 border rounded bg-black text-white [&>option]:text-black";
   const labelClasses = "block text-sm font-medium mb-1 text-white";
 
+  const handleInvalid = (
+    e: React.FormEvent<
+      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+    >
+  ) => {
+    e.currentTarget.setCustomValidity(t("form.errors.required"));
+  };
+
+  const handleInput = (
+    e: React.FormEvent<
+      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+    >
+  ) => {
+    e.currentTarget.setCustomValidity("");
+  };
+
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
@@ -150,6 +166,8 @@ export function TrackingModal({
             required={field.required}
             accept={field.accept}
             onChange={handleFileChange}
+            onInvalid={handleInvalid}
+            onInput={handleInput}
           />
         </div>
         {previewUrl && (
@@ -180,6 +198,8 @@ export function TrackingModal({
             required={field.required}
             defaultValue={field.defaultValue || ""}
             onChange={field.onChange}
+            onInvalid={handleInvalid}
+            onInput={handleInput}
           >
             {field.options?.map((option) => (
               <option key={option.value} value={option.value}>
@@ -196,6 +216,9 @@ export function TrackingModal({
             className={inputClasses}
             rows={3}
             placeholder={field.placeholder}
+            required={field.required}
+            onInvalid={handleInvalid}
+            onInput={handleInput}
           />
         );
       case "text":
@@ -207,6 +230,8 @@ export function TrackingModal({
             className="w-full p-2 border rounded bg-black text-white"
             required={field.required}
             placeholder={field.placeholder}
+            onInvalid={handleInvalid}
+            onInput={handleInput}
           />
         );
       case "number":
@@ -221,6 +246,8 @@ export function TrackingModal({
             defaultValue={field.defaultValue || ""}
             min={0}
             step="any"
+            onInvalid={handleInvalid}
+            onInput={handleInput}
           />
         );
       default:
@@ -263,6 +290,8 @@ export function TrackingModal({
                   defaultValue={field.defaultValue || ""}
                   className={inputClasses}
                   required={field.required}
+                  onInvalid={handleInvalid}
+                  onInput={handleInput}
                 />
               ) : (
                 renderField(field)

--- a/app/components/tracking/TrackingSection.tsx
+++ b/app/components/tracking/TrackingSection.tsx
@@ -31,6 +31,10 @@ export function TrackingSection({
   trackingType,
   renderEventDetails,
 }: TrackingSectionProps) {
+  const getTranslatedType = (type: string) => {
+    return t(`tracking.${trackingType}.types.${type}`);
+  };
+
   return (
     <div className="bg-white shadow rounded-lg p-6">
       <div className="flex justify-between items-center mb-4">
@@ -63,7 +67,7 @@ export function TrackingSection({
                 <div className="flex-1">
                   <div className="flex justify-between">
                     <span className="font-medium text-gray-500">
-                      {event.type}
+                      {getTranslatedType(event.type)}
                     </span>
                     <span className="text-gray-500">
                       {new Date(

--- a/app/src/translations/en.ts
+++ b/app/src/translations/en.ts
@@ -189,6 +189,11 @@ export const en = {
     delete: 'Delete',
     deleteConfirmation: 'Are you sure you want to delete this photo?',
   },
+  form: {
+    errors: {
+      required: "Please fill out this field.",
+    },
+  },
   // Add more translation categories as needed
 };
 

--- a/app/src/translations/es.ts
+++ b/app/src/translations/es.ts
@@ -192,5 +192,10 @@ export const es: TranslationKeys = {
     delete: 'Eliminar',
     deleteConfirmation: '¿Estás seguro de querer eliminar esta foto?',
   },
+  form: {
+    errors: {
+      required: "Por favor, completa este campo.",
+    },
+  },
   // Add more translation categories as needed
 };


### PR DESCRIPTION
Some translations were missing at the Spanish version of the tracking section details ("wet, dirty, breast, nap...")
- Fixed by adding a `getTranslatedType` function to `TrackingSectionProps`
Validation messages on required fields were browser's default, making it inconsistent with our native translation system
- Added handlers for custom validation messages on the required fields ("please fill out this field") 

<img width="1231" alt="image" src="https://github.com/user-attachments/assets/425b58ce-b288-46e6-ab8e-a13c6780bfe0" />
