### PR TITLE
add custom datetime picker

### DIFF
--- a/app/components/DateTimePicker.tsx
+++ b/app/components/DateTimePicker.tsx
@@ -1,0 +1,300 @@
+import { useState, useRef, useEffect } from "react";
+import { DayPicker } from "react-day-picker";
+import { format, isValid, setHours, setMinutes, getYear } from "date-fns";
+import { enUS } from "date-fns/locale/en-US";
+import { es } from "date-fns/locale/es";
+import { t } from "../src/utils/translate";
+
+const locales = { en: enUS, es };
+
+interface DateTimePickerProps {
+  value: string | null;
+  onChange: (val: string) => void;
+  locale?: "en" | "es";
+  open: boolean;
+  onClose: () => void;
+}
+
+export function DateTimePicker({
+  value,
+  onChange,
+  locale = "en",
+  open,
+  onClose,
+}: DateTimePickerProps) {
+  const popupRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLButtonElement>(null);
+  // Only store the selected day (no time)
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>(
+    value && isValid(new Date(value)) ? new Date(value) : undefined
+  );
+  // Store time separately as strings to allow empty input
+  const [tempTime, setTempTime] = useState({
+    hour:
+      value && isValid(new Date(value))
+        ? String(new Date(value).getHours()).padStart(2, "0")
+        : String(new Date().getHours()).padStart(2, "0"),
+    minute:
+      value && isValid(new Date(value))
+        ? String(new Date(value).getMinutes()).padStart(2, "0")
+        : String(new Date().getMinutes()).padStart(2, "0"),
+  });
+
+  const currentLocale = locales[locale] || enUS;
+
+  // Handle date selection (just set the date, no time)
+  const handleDateSelect = (date: Date | undefined) => {
+    if (date) {
+      // Always store only the date part (no time)
+      setSelectedDate(
+        new Date(date.getFullYear(), date.getMonth(), date.getDate())
+      );
+    }
+  };
+
+  // Handle time change
+  const handleTimeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    // Allow empty string, but only digits otherwise
+    if (value === "" || /^\d{0,2}$/.test(value)) {
+      setTempTime((prev) => ({ ...prev, [name]: value }));
+    }
+  };
+
+  // Validation for time fields
+  const hourNum = parseInt(tempTime.hour, 10);
+  const minuteNum = parseInt(tempTime.minute, 10);
+  let timeError = "";
+  if (tempTime.hour === "" || isNaN(hourNum) || hourNum < 0 || hourNum > 23) {
+    timeError =
+      t("form.errors.invalidHour") || "Please enter a valid hour (0-23)";
+  } else if (
+    tempTime.minute === "" ||
+    isNaN(minuteNum) ||
+    minuteNum < 0 ||
+    minuteNum > 59
+  ) {
+    timeError =
+      t("form.errors.invalidMinute") || "Please enter a valid minute (0-59)";
+  }
+
+  // Confirm selection: combine selectedDate and tempTime
+  const handleConfirm = () => {
+    if (selectedDate) {
+      // Parse hour/minute, fallback to 0 if invalid
+      const hour = parseInt(tempTime.hour, 10);
+      const minute = parseInt(tempTime.minute, 10);
+      if (
+        isNaN(hour) ||
+        hour < 0 ||
+        hour > 23 ||
+        isNaN(minute) ||
+        minute < 0 ||
+        minute > 59
+      ) {
+        // Optionally show an error or just return
+        return;
+      }
+      const finalDateTime = setHours(
+        setMinutes(new Date(selectedDate), minute),
+        hour
+      );
+      onClose();
+      onChange(format(finalDateTime, "yyyy-MM-dd'T'HH:mm"));
+    }
+  };
+
+  // Cancel selection
+  const handleCancel = () => {
+    onClose();
+  };
+
+  // Set today and current time
+  const handleToday = () => {
+    const now = new Date();
+    setSelectedDate(new Date(now.getFullYear(), now.getMonth(), now.getDate()));
+    setTempTime({
+      hour: String(now.getHours()).padStart(2, "0"),
+      minute: String(now.getMinutes()).padStart(2, "0"),
+    });
+  };
+
+  // Focus trap for accessibility
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Tab") {
+        const focusableEls = popupRef.current?.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (!focusableEls || focusableEls.length === 0) return;
+        const firstEl = focusableEls[0];
+        const lastEl = focusableEls[focusableEls.length - 1];
+        if (event.shiftKey) {
+          if (document.activeElement === firstEl) {
+            event.preventDefault();
+            lastEl.focus();
+          }
+        } else {
+          if (document.activeElement === lastEl) {
+            event.preventDefault();
+            firstEl.focus();
+          }
+        }
+      } else if (event.key === "Escape") {
+        onClose();
+        inputRef.current?.focus();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open]);
+
+  // Close on outside click/touch
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(event: MouseEvent | TouchEvent) {
+      if (
+        popupRef.current &&
+        !popupRef.current.contains(event.target as Node)
+      ) {
+        onClose();
+        inputRef.current?.focus();
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("touchstart", handleClick);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("touchstart", handleClick);
+    };
+  }, [open]);
+
+  // Custom month label to capitalize in Spanish
+  const getMonthLabel = (date: Date) => {
+    const month = format(date, "LLLL", { locale: currentLocale });
+    return month.charAt(0).toUpperCase() + month.slice(1) + ` ${getYear(date)}`;
+  };
+
+  if (!open) return null;
+  return (
+    <div
+      ref={popupRef}
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40"
+    >
+      <div
+        className="bg-neutral-800 shadow-lg w-full max-w-xs sm:max-w-md rounded-lg border-2 border-neutral-600 animate-fade-in py-4 px-4 max-h-[90vh] overflow-y-auto flex flex-col"
+        style={{ maxHeight: "90vh" }}
+      >
+        {/* Selected Date Label */}
+        {selectedDate && (
+          <div className="mb-2 text-center text-cyan-400 font-semibold">
+            {t("form.datePicker.selected") || "Selected"}:{" "}
+            {format(selectedDate, "P", { locale: currentLocale })}
+          </div>
+        )}
+        {/* Calendar */}
+        <div className="mb-4">
+          <DayPicker
+            mode="single"
+            selected={selectedDate}
+            onSelect={handleDateSelect}
+            locale={currentLocale}
+            className="w-full"
+            formatters={{
+              formatCaption: (date) => getMonthLabel(date),
+            }}
+            classNames={{
+              months:
+                "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
+              month: "space-y-4",
+              caption: "flex justify-center pt-1 relative items-center",
+              caption_label: "text-sm font-medium",
+              nav: "space-x-1 flex items-center",
+              nav_button:
+                "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100",
+              nav_button_previous: "absolute left-1",
+              nav_button_next: "absolute right-1",
+              table: "w-full border-collapse space-y-1",
+              head_row: "flex",
+              head_cell:
+                "text-black-600 rounded-md w-8 font-normal text-[0.8rem]",
+              row: "flex w-full mt-2",
+              cell: "text-center text-sm p-0 relative [&:has([aria-selected])]:bg-gray-100 first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+              day: "h-8 w-8 p-0 font-normal rounded-md transition-colors duration-150",
+              selected: "bg-cyan-600 text-white font-bold shadow-md",
+              day_selected: "bg-cyan-600 text-white font-bold shadow-md",
+              day_today: "border border-cyan-400",
+              day_outside: "text-gray-400 opacity-50",
+              day_disabled: "text-gray-400 opacity-50",
+              day_range_middle:
+                "aria-selected:bg-gray-100 aria-selected:text-gray-900",
+              day_hidden: "invisible",
+            }}
+          />
+        </div>
+
+        {/* Today Button */}
+        <button
+          type="button"
+          onClick={handleToday}
+          className="mb-4 w-full py-2 bg-gray-800 text-white rounded hover:bg-cyan-700 transition"
+          aria-label={t("form.datePicker.today") || "Today"}
+        >
+          {t("form.datePicker.today") || "Today"}
+        </button>
+
+        {/* Time Picker */}
+        <div className="flex gap-2 mb-2">
+          <input
+            type="number"
+            name="hour"
+            min={0}
+            max={23}
+            value={tempTime.hour}
+            onChange={handleTimeChange}
+            className="w-16 p-2 rounded border border-gray-200 text-black bg-white"
+            aria-label={t("form.datePicker.hour")}
+          />
+          <span className="text-black">:</span>
+          <input
+            type="number"
+            name="minute"
+            min={0}
+            max={59}
+            value={tempTime.minute}
+            onChange={handleTimeChange}
+            className="w-16 p-2 rounded border border-gray-200 text-black bg-white"
+            aria-label={t("form.datePicker.minute")}
+          />
+        </div>
+        {timeError && (
+          <div className="text-red-500 text-xs mb-2">{timeError}</div>
+        )}
+
+        {/* Sticky button row */}
+        <div className="flex justify-end gap-2 pt-2 bg-neutral-800 sticky bottom-0 z-10">
+          <button
+            type="button"
+            onClick={handleCancel}
+            className="mr-2 text-gray-300 hover:text-cyan-400"
+            aria-label={t("form.datePicker.close") || "Close"}
+          >
+            {t("form.datePicker.close")}
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            className="bg-cyan-600 text-white px-3 py-1 rounded hover:bg-cyan-700"
+            disabled={!selectedDate || !!timeError}
+            aria-label={t("form.datePicker.confirm") || "Confirm"}
+          >
+            {t("form.datePicker.confirm")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/translations/en.ts
+++ b/app/src/translations/en.ts
@@ -206,6 +206,21 @@ export const en = {
       invalidFileType: "Invalid file format.",
       fileTooLarge: "File is too large. Maximum size is 5MB.",
       uploadFailed: "Failed to upload photo. Please try again.",
+      invalidHour: "Please enter a valid hour (0-23)",
+      invalidMinute: "Please enter a valid minute (0-59)",
+    },
+    datePicker: {
+      placeholder: "Select date and time",
+      confirm: "Confirm",
+      close: "Close",
+      today: "Today",
+      month: "Month",
+      year: "Year",
+      hour: "Hour",
+      minute: "Minute",
+      am: "AM",
+      pm: "PM",
+      selected: "Selected"
     },
   },
   // Add more translation categories as needed

--- a/app/src/translations/es.ts
+++ b/app/src/translations/es.ts
@@ -209,7 +209,21 @@ export const es: TranslationKeys = {
       invalidFileType: "Formato de archivo no válido.",
       fileTooLarge: "El archivo es demasiado grande. Tamaño máximo 5MB.",
       uploadFailed: "Error al subir la foto. Por favor intenta de nuevo.",
+      invalidHour: "Por favor ingresa una hora válida (0-23)",
+      invalidMinute: "Por favor ingresa un minuto válido (0-59)",
+    },
+    datePicker: {
+      placeholder: "Selecciona fecha y hora",
+      confirm: "Confirmar",
+      close: "Cerrar",
+      today: "Hoy",
+      month: "Mes",
+      year: "Año",
+      hour: "Hora",
+      minute: "Minuto",
+      am: "AM",
+      pm: "PM",
+      selected: "Seleccionado"
     },
   },
-  // Add more translation categories as needed
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,12 @@
         "@remix-run/react": "2.16.4",
         "@remix-run/server-runtime": "2.16.4",
         "bcryptjs": "^3.0.2",
+        "date-fns": "^4.1.0",
         "estree-util-value-to-estree": "^3.3.3",
         "isbot": "5.1.25",
         "lucide-react": "^0.503.0",
         "react": "18.3.1",
+        "react-day-picker": "^9.7.0",
         "react-dom": "18.3.1"
       },
       "devDependencies": {
@@ -46,7 +48,7 @@
         "tailwindcss": "3.4.17",
         "tsx": "^4.19.4",
         "typescript": "5.8.2",
-        "vite": "5.4.14",
+        "vite": "^5.4.19",
         "vite-tsconfig-paths": "5.1.4",
         "vitest": "^3.1.2",
         "wrangler": "^3.114.7"
@@ -1533,6 +1535,7 @@
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -1545,6 +1548,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1659,6 +1663,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.2.0.tgz",
+      "integrity": "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.4.3",
@@ -2142,10 +2152,11 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2208,10 +2219,11 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2289,6 +2301,7 @@
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14"
       }
@@ -5203,6 +5216,7 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
       "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -5473,6 +5487,7 @@
       "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
       "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "printable-characters": "^1.0.42"
       }
@@ -5698,10 +5713,11 @@
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -6385,6 +6401,22 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -7204,10 +7236,11 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -7297,10 +7330,11 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -7363,10 +7397,11 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -7439,10 +7474,11 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -8229,6 +8265,7 @@
       "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
       "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
       "dev": true,
+      "license": "Unlicense",
       "dependencies": {
         "data-uri-to-buffer": "^2.0.0",
         "source-map": "^0.6.1"
@@ -8238,13 +8275,15 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
       "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/get-source/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8326,7 +8365,8 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/globals": {
       "version": "11.12.0",
@@ -10825,10 +10865,11 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "3.20250408.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250408.0.tgz",
-      "integrity": "sha512-URXD7+b0tLbBtchPM/MfWYujymHUrmPtd3EDQbe51qrPPF1zQCdSeNbA4f/GRQMoQIEE6EIhvEYjVjL+hiN+Og==",
+      "version": "3.20250408.2",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250408.2.tgz",
+      "integrity": "sha512-uTs7cGWFErgJTKtBdmtctwhuoxniuCQqDT8+xaEiJdEC8d+HsaZVYfZwIX2NuSmdAiHMe7NtbdZYjFMbIXtJsQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "acorn": "8.14.0",
@@ -10854,6 +10895,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10866,6 +10908,7 @@
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
       "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -10878,6 +10921,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -11136,6 +11180,7 @@
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "mustache": "bin/mustache"
       }
@@ -12157,7 +12202,8 @@
       "version": "1.0.42",
       "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
       "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
-      "dev": true
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/prisma": {
       "version": "6.8.2",
@@ -12367,6 +12413,27 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.7.0.tgz",
+      "integrity": "sha512-urlK4C9XJZVpQ81tmVgd2O7lZ0VQldZeHzNejbwLWZSkzHH498KnArT0EHNfKBOWwKc935iMLGZdxXPRISzUxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "1.2.0",
+        "date-fns": "4.1.0",
+        "date-fns-jalali": "4.1.0-0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {
@@ -13380,6 +13447,7 @@
       "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.1.8.tgz",
       "integrity": "sha512-Kpij9riA+UNg7TnphqjH7/CzctQ/owJGNbFkfEeve4Z4uxT5+JapVLFXcsurIfN34gnTWZNJ/f7NMG0E8JDzTw==",
       "dev": true,
+      "license": "Unlicense",
       "dependencies": {
         "as-table": "^1.0.36",
         "get-source": "^2.0.12"
@@ -13405,6 +13473,7 @@
       "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
       "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4",
         "npm": ">=6"
@@ -13857,10 +13926,11 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
-      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -15208,10 +15278,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.14",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
-      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
+      "version": "5.4.19",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
+      "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -16038,10 +16109,11 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "3.114.7",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.7.tgz",
-      "integrity": "sha512-awyHVA9JwcEpyysh7Kn69NoIe2SwXYt8pOjNX3p/4RsOa68qtct+QbhUCwPFPyDDH9lg1VgvTjCFfFbXBLMk6w==",
+      "version": "3.114.10",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.10.tgz",
+      "integrity": "sha512-UMs4bSH+P47oXvXqgziRqD8UOT8KBF6D/4O0bB9Kyh9QrT1FGpG2p4rV4FtbKFOchDrXQozbthScND+vLc8gqw==",
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.3.4",
         "@cloudflare/unenv-preset": "2.0.2",
@@ -16049,7 +16121,7 @@
         "@esbuild-plugins/node-modules-polyfill": "0.2.2",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.17.19",
-        "miniflare": "3.20250408.0",
+        "miniflare": "3.20250408.2",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.14",
         "workerd": "1.20250408.0"
@@ -16667,6 +16739,7 @@
       "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
       "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cookie": "^0.7.1",
         "mustache": "^4.2.0",
@@ -16678,6 +16751,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
       "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -17897,6 +17971,11 @@
       "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==",
       "dev": true
     },
+    "@date-fns/tz": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.2.0.tgz",
+      "integrity": "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg=="
+    },
     "@emnapi/runtime": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
@@ -18132,9 +18211,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.12",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -18185,9 +18264,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.12",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -20635,9 +20714,9 @@
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0"
@@ -21102,6 +21181,16 @@
         "es-errors": "^1.3.0",
         "is-data-view": "^1.0.1"
       }
+    },
+    "date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
+    },
+    "date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg=="
     },
     "debug": {
       "version": "4.4.0",
@@ -21651,9 +21740,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.12",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -21772,9 +21861,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.12",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -21852,9 +21941,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.12",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -21899,9 +21988,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.12",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -24272,9 +24361,9 @@
       "dev": true
     },
     "miniflare": {
-      "version": "3.20250408.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250408.0.tgz",
-      "integrity": "sha512-URXD7+b0tLbBtchPM/MfWYujymHUrmPtd3EDQbe51qrPPF1zQCdSeNbA4f/GRQMoQIEE6EIhvEYjVjL+hiN+Og==",
+      "version": "3.20250408.2",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250408.2.tgz",
+      "integrity": "sha512-uTs7cGWFErgJTKtBdmtctwhuoxniuCQqDT8+xaEiJdEC8d+HsaZVYfZwIX2NuSmdAiHMe7NtbdZYjFMbIXtJsQ==",
       "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "0.8.1",
@@ -25366,6 +25455,16 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "requires": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "react-day-picker": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.7.0.tgz",
+      "integrity": "sha512-urlK4C9XJZVpQ81tmVgd2O7lZ0VQldZeHzNejbwLWZSkzHH498KnArT0EHNfKBOWwKc935iMLGZdxXPRISzUxQ==",
+      "requires": {
+        "@date-fns/tz": "1.2.0",
+        "date-fns": "4.1.0",
+        "date-fns-jalali": "4.1.0-0"
       }
     },
     "react-dom": {
@@ -26533,9 +26632,9 @@
       }
     },
     "tar-fs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
-      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
       "dev": true,
       "requires": {
         "chownr": "^1.1.1",
@@ -27378,9 +27477,9 @@
       }
     },
     "vite": {
-      "version": "5.4.14",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
-      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
+      "version": "5.4.19",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
+      "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
       "requires": {
         "esbuild": "^0.21.3",
@@ -27826,9 +27925,9 @@
       }
     },
     "wrangler": {
-      "version": "3.114.7",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.7.tgz",
-      "integrity": "sha512-awyHVA9JwcEpyysh7Kn69NoIe2SwXYt8pOjNX3p/4RsOa68qtct+QbhUCwPFPyDDH9lg1VgvTjCFfFbXBLMk6w==",
+      "version": "3.114.10",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.10.tgz",
+      "integrity": "sha512-UMs4bSH+P47oXvXqgziRqD8UOT8KBF6D/4O0bB9Kyh9QrT1FGpG2p4rV4FtbKFOchDrXQozbthScND+vLc8gqw==",
       "dev": true,
       "requires": {
         "@cloudflare/kv-asset-handler": "0.3.4",
@@ -27838,7 +27937,7 @@
         "blake3-wasm": "2.1.5",
         "esbuild": "0.17.19",
         "fsevents": "~2.3.2",
-        "miniflare": "3.20250408.0",
+        "miniflare": "3.20250408.2",
         "path-to-regexp": "6.3.0",
         "sharp": "^0.33.5",
         "unenv": "2.0.0-rc.14",

--- a/package.json
+++ b/package.json
@@ -42,10 +42,12 @@
     "@remix-run/react": "2.16.4",
     "@remix-run/server-runtime": "2.16.4",
     "bcryptjs": "^3.0.2",
+    "date-fns": "^4.1.0",
     "estree-util-value-to-estree": "^3.3.3",
     "isbot": "5.1.25",
     "lucide-react": "^0.503.0",
     "react": "18.3.1",
+    "react-day-picker": "^9.7.0",
     "react-dom": "18.3.1"
   },
   "devDependencies": {
@@ -74,7 +76,7 @@
     "tailwindcss": "3.4.17",
     "tsx": "^4.19.4",
     "typescript": "5.8.2",
-    "vite": "5.4.14",
+    "vite": "^5.4.19",
     "vite-tsconfig-paths": "5.1.4",
     "vitest": "^3.1.2",
     "wrangler": "^3.114.7"


### PR DESCRIPTION
We were using the browser's default date/time picker for all user date/time inputs, which was untranslatable with our current `t(...` method (not to mention lame); so I wanted to try out a semi-custom pop-up with calendar and time inputs, using react-day-picker and date-fns:
<img width="517" alt="image" src="https://github.com/user-attachments/assets/5b1cbff7-3a01-47f1-a159-8f6f57937ca7" />

This is now our internal component for date and time inputs; it required:
- Installing react-day-picker and date-fns dependencies
- Creating `DateTimePicker.tsx`, a component for the UI and logic
- Updating `TrackingModal`, the translation dictionaries, and tweaking the date/time parsing logic a bit